### PR TITLE
Create fr_fr.json

### DIFF
--- a/src/main/resources/assets/blast/lang/fr_fr.json
+++ b/src/main/resources/assets/blast/lang/fr_fr.json
@@ -5,5 +5,5 @@
   "item.blast.pulveris": "Pulveris",
   "item.blast.naval_mine": "Mine navale",
   "block.blast.gunpowder_block": "Bloc de poudre à canon",
-  "block.blast.stripminer": "Mineur de bande"
+  "block.blast.stripminer": "Lamineur"
 }

--- a/src/main/resources/assets/blast/lang/fr_fr.json
+++ b/src/main/resources/assets/blast/lang/fr_fr.json
@@ -1,0 +1,9 @@
+{
+  "item.blast.bomb": "Bombe",
+  "item.blast.golden_bomb": "Bombe en or",
+  "item.blast.diamond_bomb": "Bombe en diamant",
+  "item.blast.pulveris": "Pulveris",
+  "item.blast.naval_mine": "Mine navale",
+  "block.blast.gunpowder_block": "Bloc de poudre à canon",
+  "block.blast.stripminer": "Mineur de bande"
+}


### PR DESCRIPTION
"Stripminer" was hard to translate. According to the guides on the Minecraft wiki "strip mining" can be translated as "minage par bande" in french, so that's what I went with. But it sounds bad, but like just keeping "stripminer" also sounded off with the other french stuff.