### PR TITLE
Implement FLAN compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,20 @@ group = project.maven_group
 minecraft {
 }
 
+repositories {
+	maven {
+        name = "Flemmli97"
+        url "https://gitlab.com/api/v4/projects/21830712/packages/maven"
+    }
+
+	maven {
+		url "https://www.cursemaven.com"
+		content {
+			includeGroup "curse.maven"
+		}
+	}
+}
+
 dependencies {
 	//to change the versions see the gradle.properties file
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
@@ -31,6 +45,14 @@ dependencies {
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.
+
+	modCompileOnly("io.github.flemmli97:flan:${minecraft_version}-${flan_version}:fabric-api") {
+		transitive = false
+	}
+
+    modRuntime("io.github.flemmli97:flan:${minecraft_version}-${flan_version}:fabric") {
+		transitive = false
+	}
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,9 @@ minecraft {
 
 repositories {
 	maven {
-        name = "Flemmli97"
-        url "https://gitlab.com/api/v4/projects/21830712/packages/maven"
-    }
+		name = "Flemmli97"
+		url "https://gitlab.com/api/v4/projects/21830712/packages/maven"
+	}
 
 	maven {
 		url "https://www.cursemaven.com"
@@ -50,7 +50,7 @@ dependencies {
 		transitive = false
 	}
 
-    modRuntime("io.github.flemmli97:flan:${minecraft_version}-${flan_version}:fabric") {
+	modRuntime("io.github.flemmli97:flan:${minecraft_version}-${flan_version}:fabric") {
 		transitive = false
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,8 @@ loader_version=0.12.8
 #Fabric api
 fabric_version=0.43.1+1.18
 
-
+#Dependencies
+flan_version=1.6.6
 
 #Publishing
 owners = Ladysnake

--- a/src/main/java/ladysnake/blast/common/compat/FlanCompat.java
+++ b/src/main/java/ladysnake/blast/common/compat/FlanCompat.java
@@ -1,0 +1,18 @@
+package ladysnake.blast.common.compat;
+
+import io.github.flemmli97.flan.api.ClaimHandler;
+import io.github.flemmli97.flan.api.data.IPermissionContainer;
+import io.github.flemmli97.flan.api.data.IPermissionStorage;
+import io.github.flemmli97.flan.api.permission.ClaimPermission;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+
+public class FlanCompat {
+    public static boolean canInteract(ServerWorld world, ServerPlayerEntity player, BlockPos pos, ClaimPermission type) {
+        IPermissionStorage storage = ClaimHandler.getPermissionStorage(world);
+        IPermissionContainer container = storage.getForPermissionCheck(pos);
+
+        return container.canInteract(player, type, pos);
+    }
+}

--- a/src/main/java/ladysnake/blast/common/item/BombItem.java
+++ b/src/main/java/ladysnake/blast/common/item/BombItem.java
@@ -1,11 +1,18 @@
 package ladysnake.blast.common.item;
 
+import io.github.flemmli97.flan.api.ClaimHandler;
+import io.github.flemmli97.flan.api.data.IPermissionContainer;
+import io.github.flemmli97.flan.api.data.IPermissionStorage;
+import io.github.flemmli97.flan.api.permission.PermissionRegistry;
 import ladysnake.blast.common.entity.BombEntity;
 import ladysnake.blast.common.item.bombards.BombardItem;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.stat.Stats;
@@ -25,6 +32,15 @@ public class BombItem extends Item {
     }
 
     public TypedActionResult<ItemStack> use(World world, PlayerEntity playerEntity, Hand hand) {
+        if (FabricLoader.getInstance().isModLoaded("flan") && world instanceof ServerWorld serverWorld && playerEntity instanceof ServerPlayerEntity serverPlayer) {
+            IPermissionStorage storage = ClaimHandler.getPermissionStorage(serverWorld);
+            IPermissionContainer container = storage.getForPermissionCheck(serverPlayer.getBlockPos());
+
+            if (!container.canInteract(serverPlayer, PermissionRegistry.INTERACTBLOCK, serverPlayer.getBlockPos())) {
+                return new TypedActionResult<>(ActionResult.PASS, playerEntity.getStackInHand(hand));
+            }
+        }
+
         if (hand == Hand.OFF_HAND && playerEntity.getStackInHand(Hand.MAIN_HAND).getItem() instanceof BombardItem) {
             return new TypedActionResult<>(ActionResult.PASS, playerEntity.getStackInHand(hand));
         } else {

--- a/src/main/java/ladysnake/blast/common/item/BombItem.java
+++ b/src/main/java/ladysnake/blast/common/item/BombItem.java
@@ -1,9 +1,7 @@
 package ladysnake.blast.common.item;
 
-import io.github.flemmli97.flan.api.ClaimHandler;
-import io.github.flemmli97.flan.api.data.IPermissionContainer;
-import io.github.flemmli97.flan.api.data.IPermissionStorage;
 import io.github.flemmli97.flan.api.permission.PermissionRegistry;
+import ladysnake.blast.common.compat.FlanCompat;
 import ladysnake.blast.common.entity.BombEntity;
 import ladysnake.blast.common.item.bombards.BombardItem;
 import net.fabricmc.loader.api.FabricLoader;
@@ -33,10 +31,7 @@ public class BombItem extends Item {
 
     public TypedActionResult<ItemStack> use(World world, PlayerEntity playerEntity, Hand hand) {
         if (FabricLoader.getInstance().isModLoaded("flan") && world instanceof ServerWorld serverWorld && playerEntity instanceof ServerPlayerEntity serverPlayer) {
-            IPermissionStorage storage = ClaimHandler.getPermissionStorage(serverWorld);
-            IPermissionContainer container = storage.getForPermissionCheck(serverPlayer.getBlockPos());
-
-            if (!container.canInteract(serverPlayer, PermissionRegistry.INTERACTBLOCK, serverPlayer.getBlockPos())) {
+            if (!FlanCompat.canInteract(serverWorld, serverPlayer, serverPlayer.getBlockPos(), PermissionRegistry.INTERACTBLOCK)) {
                 return new TypedActionResult<>(ActionResult.PASS, playerEntity.getStackInHand(hand));
             }
         }

--- a/src/main/java/ladysnake/blast/common/world/BlockFillingExplosion.java
+++ b/src/main/java/ladysnake/blast/common/world/BlockFillingExplosion.java
@@ -1,7 +1,9 @@
 package ladysnake.blast.common.world;
 
 import com.mojang.datafixers.util.Pair;
+import io.github.flemmli97.flan.api.permission.PermissionRegistry;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.FluidFillable;
@@ -12,6 +14,7 @@ import net.minecraft.item.Items;
 import net.minecraft.loot.context.LootContext;
 import net.minecraft.loot.context.LootContextParameters;
 import net.minecraft.particle.ParticleTypes;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
@@ -27,6 +30,15 @@ public class BlockFillingExplosion extends CustomExplosion {
     public BlockFillingExplosion(World world, Entity entity, double x, double y, double z, float power, BlockState blockStateToPlace) {
         super(world, entity, x, y, z, power, null, DestructionType.BREAK);
         this.blockStateToPlace = blockStateToPlace;
+    }
+
+    @Override
+    public void collectBlocksAndDamageEntities() {
+        super.collectBlocksAndDamageEntities();
+
+        if (FabricLoader.getInstance().isModLoaded("flan") && this.world instanceof ServerWorld world && this.getCausingEntity() instanceof ServerPlayerEntity player) {
+            affectedBlocks.removeIf(pos -> canInteract(world, player, pos, PermissionRegistry.PLACE));
+        }
     }
 
     @Override

--- a/src/main/java/ladysnake/blast/common/world/BlockFillingExplosion.java
+++ b/src/main/java/ladysnake/blast/common/world/BlockFillingExplosion.java
@@ -3,6 +3,7 @@ package ladysnake.blast.common.world;
 import com.mojang.datafixers.util.Pair;
 import io.github.flemmli97.flan.api.permission.PermissionRegistry;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import ladysnake.blast.common.compat.FlanCompat;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -37,7 +38,7 @@ public class BlockFillingExplosion extends CustomExplosion {
         super.collectBlocksAndDamageEntities();
 
         if (FabricLoader.getInstance().isModLoaded("flan") && this.world instanceof ServerWorld world && this.getCausingEntity() instanceof ServerPlayerEntity player) {
-            affectedBlocks.removeIf(pos -> canInteract(world, player, pos, PermissionRegistry.PLACE));
+            affectedBlocks.removeIf(pos -> FlanCompat.canInteract(world, player, pos, PermissionRegistry.PLACE));
         }
     }
 

--- a/src/main/java/ladysnake/blast/common/world/CustomExplosion.java
+++ b/src/main/java/ladysnake/blast/common/world/CustomExplosion.java
@@ -10,6 +10,7 @@ import io.github.flemmli97.flan.api.data.IPermissionStorage;
 import io.github.flemmli97.flan.api.permission.ClaimPermission;
 import io.github.flemmli97.flan.api.permission.PermissionRegistry;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import ladysnake.blast.common.compat.FlanCompat;
 import ladysnake.blast.common.entity.StripminerEntity;
 import ladysnake.blast.common.init.BlastBlocks;
 import net.fabricmc.loader.api.FabricLoader;
@@ -131,8 +132,8 @@ public class CustomExplosion extends Explosion {
 
                             claimCheck:
                             if (h > 0.0F && (this.entity == null || this.entity.canExplosionDestroyBlock(this, this.world, blockPos, blockState, h))) {
-                                if (FabricLoader.getInstance().isModLoaded("flan") && this.world instanceof ServerWorld world && this.getCausingEntity() instanceof ServerPlayerEntity player) {
-                                    if (!canInteract(world, player, blockPos, PermissionRegistry.BREAK)) break claimCheck;
+                                if (FabricLoader.getInstance().isModLoaded("flan") && this.world instanceof ServerWorld serverWorld && this.getCausingEntity() instanceof ServerPlayerEntity serverPlayer) {
+                                    if (!FlanCompat.canInteract(serverWorld, serverPlayer, blockPos, PermissionRegistry.BREAK)) break claimCheck;
                                 }
 
                                 set.add(blockPos);
@@ -308,13 +309,6 @@ public class CustomExplosion extends Explosion {
                 }
             }
         }
-    }
-
-    public boolean canInteract(ServerWorld world, ServerPlayerEntity player, BlockPos pos, ClaimPermission type) {
-        IPermissionStorage storage = ClaimHandler.getPermissionStorage(world);
-        IPermissionContainer container = storage.getForPermissionCheck(pos);
-
-        return container.canInteract(player, type, pos);
     }
 
     public enum BlockBreakEffect {

--- a/src/main/java/ladysnake/blast/common/world/EnderExplosion.java
+++ b/src/main/java/ladysnake/blast/common/world/EnderExplosion.java
@@ -2,7 +2,12 @@ package ladysnake.blast.common.world;
 
 import com.google.common.collect.Sets;
 import com.mojang.datafixers.util.Pair;
+import io.github.flemmli97.flan.api.ClaimHandler;
+import io.github.flemmli97.flan.api.data.IPermissionContainer;
+import io.github.flemmli97.flan.api.data.IPermissionStorage;
+import io.github.flemmli97.flan.api.permission.PermissionRegistry;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
@@ -19,6 +24,7 @@ import net.minecraft.item.Items;
 import net.minecraft.loot.context.LootContext;
 import net.minecraft.loot.context.LootContextParameters;
 import net.minecraft.particle.ParticleTypes;
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
@@ -79,7 +85,12 @@ public class EnderExplosion extends CustomExplosion {
                             }
 
 
+                            claimCheck:
                             if (h > 0.0F && (this.entity == null || this.entity.canExplosionDestroyBlock(this, this.world, blockPos, blockState, h))) {
+                                if (FabricLoader.getInstance().isModLoaded("flan") && this.world instanceof ServerWorld world && this.getCausingEntity() instanceof ServerPlayerEntity player) {
+                                    if (!canInteract(world, player, blockPos, PermissionRegistry.BREAK)) break claimCheck;
+                                }
+
                                 set.add(blockPos);
                             }
 
@@ -138,7 +149,6 @@ public class EnderExplosion extends CustomExplosion {
                 }
             }
         }
-
     }
 
     @Override

--- a/src/main/java/ladysnake/blast/common/world/EnderExplosion.java
+++ b/src/main/java/ladysnake/blast/common/world/EnderExplosion.java
@@ -7,6 +7,7 @@ import io.github.flemmli97.flan.api.data.IPermissionContainer;
 import io.github.flemmli97.flan.api.data.IPermissionStorage;
 import io.github.flemmli97.flan.api.permission.PermissionRegistry;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import ladysnake.blast.common.compat.FlanCompat;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -87,8 +88,8 @@ public class EnderExplosion extends CustomExplosion {
 
                             claimCheck:
                             if (h > 0.0F && (this.entity == null || this.entity.canExplosionDestroyBlock(this, this.world, blockPos, blockState, h))) {
-                                if (FabricLoader.getInstance().isModLoaded("flan") && this.world instanceof ServerWorld world && this.getCausingEntity() instanceof ServerPlayerEntity player) {
-                                    if (!canInteract(world, player, blockPos, PermissionRegistry.BREAK)) break claimCheck;
+                                if (FabricLoader.getInstance().isModLoaded("flan") && this.world instanceof ServerWorld serverWorld && this.getCausingEntity() instanceof ServerPlayerEntity serverPlayer) {
+                                    if (!FlanCompat.canInteract(serverWorld, serverPlayer, blockPos, PermissionRegistry.BREAK)) break claimCheck;
                                 }
 
                                 set.add(blockPos);

--- a/src/main/java/ladysnake/blast/common/world/EntityExplosion.java
+++ b/src/main/java/ladysnake/blast/common/world/EntityExplosion.java
@@ -32,7 +32,6 @@ public class EntityExplosion extends CustomExplosion {
             entity.setVelocity(random.nextGaussian() * velocity, random.nextGaussian() * velocity, random.nextGaussian() * velocity);
 
             world.spawnEntity(entity);
-
         }
     }
 }

--- a/src/main/java/ladysnake/blast/common/world/KnockbackExplosion.java
+++ b/src/main/java/ladysnake/blast/common/world/KnockbackExplosion.java
@@ -1,6 +1,11 @@
 package ladysnake.blast.common.world;
 
 import com.google.common.collect.Sets;
+import io.github.flemmli97.flan.api.ClaimHandler;
+import io.github.flemmli97.flan.api.data.IPermissionContainer;
+import io.github.flemmli97.flan.api.data.IPermissionStorage;
+import io.github.flemmli97.flan.api.permission.PermissionRegistry;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.BlockState;
 import net.minecraft.enchantment.ProtectionEnchantment;
 import net.minecraft.entity.Entity;
@@ -9,6 +14,8 @@ import net.minecraft.entity.TntEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.particle.ParticleTypes;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.MathHelper;
@@ -65,7 +72,12 @@ public class KnockbackExplosion extends CustomExplosion {
                             }
 
 
+                            claimCheck:
                             if (h > 0.0F && (this.entity == null || this.entity.canExplosionDestroyBlock(this, this.world, blockPos, blockState, h))) {
+                                if (FabricLoader.getInstance().isModLoaded("flan") && this.world instanceof ServerWorld world && this.getCausingEntity() instanceof ServerPlayerEntity player) {
+                                    if (!canInteract(world, player, blockPos, PermissionRegistry.BREAK)) break claimCheck;
+                                }
+
                                 set.add(blockPos);
                             }
 

--- a/src/main/java/ladysnake/blast/common/world/KnockbackExplosion.java
+++ b/src/main/java/ladysnake/blast/common/world/KnockbackExplosion.java
@@ -5,6 +5,7 @@ import io.github.flemmli97.flan.api.ClaimHandler;
 import io.github.flemmli97.flan.api.data.IPermissionContainer;
 import io.github.flemmli97.flan.api.data.IPermissionStorage;
 import io.github.flemmli97.flan.api.permission.PermissionRegistry;
+import ladysnake.blast.common.compat.FlanCompat;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.BlockState;
 import net.minecraft.enchantment.ProtectionEnchantment;
@@ -74,8 +75,8 @@ public class KnockbackExplosion extends CustomExplosion {
 
                             claimCheck:
                             if (h > 0.0F && (this.entity == null || this.entity.canExplosionDestroyBlock(this, this.world, blockPos, blockState, h))) {
-                                if (FabricLoader.getInstance().isModLoaded("flan") && this.world instanceof ServerWorld world && this.getCausingEntity() instanceof ServerPlayerEntity player) {
-                                    if (!canInteract(world, player, blockPos, PermissionRegistry.BREAK)) break claimCheck;
+                                if (FabricLoader.getInstance().isModLoaded("flan") && this.world instanceof ServerWorld serverWorld && this.getCausingEntity() instanceof ServerPlayerEntity serverPlayer) {
+                                    if (!FlanCompat.canInteract(serverWorld, serverPlayer, blockPos, PermissionRegistry.BREAK)) break claimCheck;
                                 }
 
                                 set.add(blockPos);


### PR DESCRIPTION
Currently, bombs from BLAST override claims from FLAN, which causes problems with potential griefing.