### PR TITLE
feat: Modifiable Explosion Radius

### DIFF
--- a/src/main/java/ladysnake/blast/common/entity/AmethystBombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/AmethystBombEntity.java
@@ -13,10 +13,12 @@ import net.minecraft.world.explosion.Explosion;
 public class AmethystBombEntity extends BombEntity {
     public AmethystBombEntity(EntityType<? extends BombEntity> entityType, World world) {
         super(entityType, world);
+        this.setExplosionRadius(70f);
     }
 
     public AmethystBombEntity(EntityType<? extends BombEntity> entityType, World world, LivingEntity livingEntity) {
         super(entityType, world, livingEntity);
+        this.setExplosionRadius(70f);
     }
 
     @Override
@@ -26,6 +28,6 @@ public class AmethystBombEntity extends BombEntity {
 
     @Override
     protected CustomExplosion getExplosion() {
-        return new EntityExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), BlastEntities.AMETHYST_SHARD, 70, 1.4f);
+        return new EntityExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), BlastEntities.AMETHYST_SHARD, Math.round(this.getExplosionRadius()), 1.4f);
     }
 }

--- a/src/main/java/ladysnake/blast/common/entity/AmethystTriggerBombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/AmethystTriggerBombEntity.java
@@ -13,10 +13,12 @@ import net.minecraft.world.explosion.Explosion;
 public class AmethystTriggerBombEntity extends TriggerBombEntity {
     public AmethystTriggerBombEntity(EntityType<? extends BombEntity> entityType, World world) {
         super(entityType, world);
+        this.setExplosionRadius(70f);
     }
 
     public AmethystTriggerBombEntity(EntityType<? extends BombEntity> entityType, World world, LivingEntity livingEntity) {
         super(entityType, world, livingEntity);
+        this.setExplosionRadius(70f);
     }
 
     @Override
@@ -26,7 +28,7 @@ public class AmethystTriggerBombEntity extends TriggerBombEntity {
 
     @Override
     protected CustomExplosion getExplosion() {
-        return new EntityExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), BlastEntities.AMETHYST_SHARD, 70, 1.4f);
+        return new EntityExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), BlastEntities.AMETHYST_SHARD, Math.round(this.getExplosionRadius()), 1.4f);
     }
 
 }

--- a/src/main/java/ladysnake/blast/common/entity/BombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/BombEntity.java
@@ -25,18 +25,21 @@ import net.minecraft.world.explosion.Explosion;
 
 public class BombEntity extends ThrownItemEntity {
     private static final TrackedData<Integer> FUSE = DataTracker.registerData(BombEntity.class, TrackedDataHandlerRegistry.INTEGER);
+    private float explosionRadius = 3f;
     public int ticksUntilRemoval;
     private int fuseTimer;
 
     public BombEntity(EntityType<? extends BombEntity> entityType, World world) {
         super(entityType, world);
         this.setFuse(40);
+        this.setExplosionRadius(3f);
         this.ticksUntilRemoval = -1;
     }
 
     public BombEntity(EntityType<? extends BombEntity> entityType, World world, LivingEntity livingEntity) {
         super(entityType, livingEntity, world);
         this.setFuse(40);
+        this.setExplosionRadius(3f);
         this.ticksUntilRemoval = -1;
     }
 
@@ -49,7 +52,7 @@ public class BombEntity extends ThrownItemEntity {
     }
 
     protected CustomExplosion getExplosion() {
-        return new CustomExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), 3f, null, Explosion.DestructionType.BREAK);
+        return new CustomExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), this.getExplosionRadius(), null, Explosion.DestructionType.BREAK);
     }
 
     @Override
@@ -151,6 +154,22 @@ public class BombEntity extends ThrownItemEntity {
         return this.fuseTimer;
     }
 
+    public float getExplosionRadius() {
+        return this.explosionRadius;
+    }
+
+    public void setExplosionRadius(float float_1) {
+        this.explosionRadius = float_1;
+    }
+
+    @Override
+    public void setItem(ItemStack item) {
+        super.setItem(new ItemStack(item.getItem()));
+        if (item.hasNbt() && item.getOrCreateNbt().contains("ExplosionRadius")) {
+            this.setExplosionRadius(item.getOrCreateNbt().getFloat("ExplosionRadius"));
+        }
+    }
+
     protected void initDataTracker() {
         this.dataTracker.startTracking(FUSE, 40);
     }
@@ -158,11 +177,13 @@ public class BombEntity extends ThrownItemEntity {
     @Override
     public void writeCustomDataToNbt(NbtCompound NbtCompound_1) {
         NbtCompound_1.putShort("Fuse", (short) this.getFuseTimer());
+        NbtCompound_1.putFloat("ExplosionRadius", this.getExplosionRadius());
     }
 
     @Override
     public void readCustomDataFromNbt(NbtCompound NbtCompound_1) {
         this.setFuse(NbtCompound_1.getShort("Fuse"));
+        this.setExplosionRadius(NbtCompound_1.getFloat("ExplosionRadius"));
     }
 
     @Override

--- a/src/main/java/ladysnake/blast/common/entity/BonesburrierEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/BonesburrierEntity.java
@@ -15,11 +15,12 @@ public class BonesburrierEntity extends BombEntity {
     public BonesburrierEntity(EntityType<? extends BombEntity> entityType, World world) {
         super(entityType, world);
         this.setFuse(80);
+        this.setExplosionRadius(8f);
     }
 
     @Override
     public void explode() {
-        CustomExplosion explosion = new BonesburrierExplosion(world, this,  this.getX(), this.getBodyY(0.0625), this.getZ(), 8f, Explosion.DestructionType.DESTROY);
+        CustomExplosion explosion = new BonesburrierExplosion(world, this,  this.getX(), this.getBodyY(0.0625), this.getZ(), this.getExplosionRadius(), Explosion.DestructionType.DESTROY);
         explosion.collectBlocksAndDamageEntities();
         explosion.affectWorld(true);
 

--- a/src/main/java/ladysnake/blast/common/entity/ColdDiggerEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/ColdDiggerEntity.java
@@ -15,6 +15,7 @@ import net.minecraft.world.explosion.Explosion;
 public class ColdDiggerEntity extends StripminerEntity {
     public ColdDiggerEntity(EntityType<? extends BombEntity> entityType, World world) {
         super(entityType, world);
+        this.setExplosionRadius(3.5f);
     }
 
     @Override
@@ -22,7 +23,7 @@ public class ColdDiggerEntity extends StripminerEntity {
         for (int i = 0; i <= 24; i++) {
             BlockPos bp = this.getBlockPos().offset(this.getFacing(), i);
             if (world.getBlockState(bp).getBlock().getBlastResistance() < 1200) {
-                CustomExplosion explosion = new CustomExplosion(world, this, bp.getX() + 0.5, bp.getY() + 0.5, bp.getZ() + 0.5, 3.5f, CustomExplosion.BlockBreakEffect.FROSTY, Explosion.DestructionType.BREAK);
+                CustomExplosion explosion = new CustomExplosion(world, this, bp.getX() + 0.5, bp.getY() + 0.5, bp.getZ() + 0.5, this.getExplosionRadius(), CustomExplosion.BlockBreakEffect.FROSTY, Explosion.DestructionType.BREAK);
                 explosion.collectBlocksAndDamageEntities();
                 explosion.affectWorld(true);
             } else {

--- a/src/main/java/ladysnake/blast/common/entity/ConfettiBombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/ConfettiBombEntity.java
@@ -14,10 +14,12 @@ import net.minecraft.world.World;
 public class ConfettiBombEntity extends BombEntity {
     public ConfettiBombEntity(EntityType<? extends BombEntity> entityType, World world) {
         super(entityType, world);
+        this.setExplosionRadius(500f);
     }
 
     public ConfettiBombEntity(EntityType<? extends BombEntity> entityType, World world, LivingEntity livingEntity) {
         super(entityType, world, livingEntity);
+        this.setExplosionRadius(500f);
     }
 
     @Override
@@ -40,7 +42,7 @@ public class ConfettiBombEntity extends BombEntity {
                 world.addParticle(ParticleTypes.POOF, this.getX(), this.getY(), this.getZ(), random.nextGaussian() / 10f, Math.abs(random.nextGaussian() / 10f), random.nextGaussian() / 10f);
             }
 
-            for (int i = 0; i < 500; i++) {
+            for (int i = 0; i < Math.round(this.getExplosionRadius()); i++) {
                 world.addParticle(BlastClient.CONFETTI, this.getX(), this.getY(), this.getZ(), random.nextGaussian() / 8f, Math.abs(random.nextGaussian() / 8f), random.nextGaussian() / 8f);
             }
 

--- a/src/main/java/ladysnake/blast/common/entity/ConfettiTriggerBombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/ConfettiTriggerBombEntity.java
@@ -14,10 +14,12 @@ import net.minecraft.world.World;
 public class ConfettiTriggerBombEntity extends TriggerBombEntity {
     public ConfettiTriggerBombEntity(EntityType<? extends BombEntity> entityType, World world) {
         super(entityType, world);
+        this.setExplosionRadius(500f);
     }
 
     public ConfettiTriggerBombEntity(EntityType<? extends BombEntity> entityType, World world, LivingEntity livingEntity) {
         super(entityType, world, livingEntity);
+        this.setExplosionRadius(500f);
     }
 
     @Override
@@ -40,7 +42,7 @@ public class ConfettiTriggerBombEntity extends TriggerBombEntity {
                 world.addParticle(ParticleTypes.POOF, this.getX(), this.getY(), this.getZ(), random.nextGaussian() / 10f, Math.abs(random.nextGaussian() / 10f), random.nextGaussian() / 10f);
             }
 
-            for (int i = 0; i < 500; i++) {
+            for (int i = 0; i < Math.round(this.getExplosionRadius()); i++) {
                 world.addParticle(BlastClient.CONFETTI, this.getX(), this.getY(), this.getZ(), random.nextGaussian() / 8f, Math.abs(random.nextGaussian() / 8f), random.nextGaussian() / 8f);
             }
 

--- a/src/main/java/ladysnake/blast/common/entity/DiamondBombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/DiamondBombEntity.java
@@ -24,6 +24,6 @@ public class DiamondBombEntity extends BombEntity {
 
     @Override
     public CustomExplosion getExplosion() {
-        return new CustomExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), 3f, CustomExplosion.BlockBreakEffect.UNSTOPPABLE, Explosion.DestructionType.BREAK);
+        return new CustomExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), this.getExplosionRadius(), CustomExplosion.BlockBreakEffect.UNSTOPPABLE, Explosion.DestructionType.BREAK);
     }
 }

--- a/src/main/java/ladysnake/blast/common/entity/DiamondTriggerBombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/DiamondTriggerBombEntity.java
@@ -24,7 +24,7 @@ public class DiamondTriggerBombEntity extends TriggerBombEntity {
 
     @Override
     public CustomExplosion getExplosion() {
-        return new CustomExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), 3f, CustomExplosion.BlockBreakEffect.UNSTOPPABLE, Explosion.DestructionType.BREAK);
+        return new CustomExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), this.getExplosionRadius(), CustomExplosion.BlockBreakEffect.UNSTOPPABLE, Explosion.DestructionType.BREAK);
     }
 
 }

--- a/src/main/java/ladysnake/blast/common/entity/DirtBombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/DirtBombEntity.java
@@ -12,10 +12,12 @@ import net.minecraft.world.World;
 public class DirtBombEntity extends BombEntity {
     public DirtBombEntity(EntityType<? extends BombEntity> entityType, World world) {
         super(entityType, world);
+        this.setExplosionRadius(2f);
     }
 
     public DirtBombEntity(EntityType<? extends BombEntity> entityType, World world, LivingEntity livingEntity) {
         super(entityType, world, livingEntity);
+        this.setExplosionRadius(2f);
     }
 
     @Override
@@ -25,6 +27,6 @@ public class DirtBombEntity extends BombEntity {
 
     @Override
     protected CustomExplosion getExplosion() {
-        return new BlockFillingExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), 2f, Blocks.DIRT.getDefaultState());
+        return new BlockFillingExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), this.getExplosionRadius(), Blocks.DIRT.getDefaultState());
     }
 }

--- a/src/main/java/ladysnake/blast/common/entity/DirtTriggerBombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/DirtTriggerBombEntity.java
@@ -12,10 +12,12 @@ import net.minecraft.world.World;
 public class DirtTriggerBombEntity extends TriggerBombEntity {
     public DirtTriggerBombEntity(EntityType<? extends BombEntity> entityType, World world) {
         super(entityType, world);
+        this.setExplosionRadius(2f);
     }
 
     public DirtTriggerBombEntity(EntityType<? extends BombEntity> entityType, World world, LivingEntity livingEntity) {
         super(entityType, world, livingEntity);
+        this.setExplosionRadius(2f);
     }
 
     @Override
@@ -25,7 +27,7 @@ public class DirtTriggerBombEntity extends TriggerBombEntity {
 
     @Override
     protected CustomExplosion getExplosion() {
-        return new BlockFillingExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), 2f, Blocks.DIRT.getDefaultState());
+        return new BlockFillingExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), this.getExplosionRadius(), Blocks.DIRT.getDefaultState());
     }
 
 }

--- a/src/main/java/ladysnake/blast/common/entity/FrostBombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/FrostBombEntity.java
@@ -13,10 +13,12 @@ import net.minecraft.world.explosion.Explosion;
 public class FrostBombEntity extends BombEntity {
     public FrostBombEntity(EntityType<? extends BombEntity> entityType, World world) {
         super(entityType, world);
+        this.setExplosionRadius(70f);
     }
 
     public FrostBombEntity(EntityType<? extends BombEntity> entityType, World world, LivingEntity livingEntity) {
         super(entityType, world, livingEntity);
+        this.setExplosionRadius(70f);
     }
 
     @Override
@@ -26,6 +28,6 @@ public class FrostBombEntity extends BombEntity {
 
     @Override
     protected CustomExplosion getExplosion() {
-        return new EntityExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), BlastEntities.ICICLE, 70, 1.4f);
+        return new EntityExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), BlastEntities.ICICLE, Math.round(this.getExplosionRadius()), 1.4f);
     }
 }

--- a/src/main/java/ladysnake/blast/common/entity/FrostTriggerBombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/FrostTriggerBombEntity.java
@@ -13,10 +13,12 @@ import net.minecraft.world.explosion.Explosion;
 public class FrostTriggerBombEntity extends TriggerBombEntity {
     public FrostTriggerBombEntity(EntityType<? extends BombEntity> entityType, World world) {
         super(entityType, world);
+        this.setExplosionRadius(70f);
     }
 
     public FrostTriggerBombEntity(EntityType<? extends BombEntity> entityType, World world, LivingEntity livingEntity) {
         super(entityType, world, livingEntity);
+        this.setExplosionRadius(70f);
     }
 
     @Override
@@ -26,7 +28,7 @@ public class FrostTriggerBombEntity extends TriggerBombEntity {
 
     @Override
     protected CustomExplosion getExplosion() {
-        return new EntityExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), BlastEntities.ICICLE, 70, 1.4f);
+        return new EntityExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), BlastEntities.ICICLE, Math.round(this.getExplosionRadius()), 1.4f);
     }
 
 }

--- a/src/main/java/ladysnake/blast/common/entity/GoldenBombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/GoldenBombEntity.java
@@ -24,6 +24,6 @@ public class GoldenBombEntity extends BombEntity {
 
     @Override
     protected CustomExplosion getExplosion() {
-        return new CustomExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), 3f, CustomExplosion.BlockBreakEffect.FORTUNE, Explosion.DestructionType.BREAK);
+        return new CustomExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), this.getExplosionRadius(), CustomExplosion.BlockBreakEffect.FORTUNE, Explosion.DestructionType.BREAK);
     }
 }

--- a/src/main/java/ladysnake/blast/common/entity/GoldenTriggerBombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/GoldenTriggerBombEntity.java
@@ -24,7 +24,7 @@ public class GoldenTriggerBombEntity extends TriggerBombEntity {
 
     @Override
     protected CustomExplosion getExplosion() {
-        return new CustomExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), 3f, CustomExplosion.BlockBreakEffect.FORTUNE, Explosion.DestructionType.BREAK);
+        return new CustomExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), this.getExplosionRadius(), CustomExplosion.BlockBreakEffect.FORTUNE, Explosion.DestructionType.BREAK);
     }
 
 }

--- a/src/main/java/ladysnake/blast/common/entity/GunpowderBlockEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/GunpowderBlockEntity.java
@@ -13,10 +13,12 @@ public class GunpowderBlockEntity extends BombEntity {
     public GunpowderBlockEntity(EntityType<? extends BombEntity> entityType, World world) {
         super(entityType, world);
         this.setFuse(1);
+        this.setExplosionRadius(4f);
     }
 
     public GunpowderBlockEntity(EntityType<? extends BombEntity> entityType, World world, LivingEntity livingEntity) {
         super(entityType, world, livingEntity);
+        this.setExplosionRadius(4f);
     }
 
     @Override
@@ -26,6 +28,6 @@ public class GunpowderBlockEntity extends BombEntity {
 
     @Override
     protected CustomExplosion getExplosion() {
-        return new CustomExplosion(this.world, this, this.getX(), this.getY(), this.getZ(), 4f, CustomExplosion.BlockBreakEffect.FIERY, Explosion.DestructionType.DESTROY);
+        return new CustomExplosion(this.world, this, this.getX(), this.getY(), this.getZ(), this.getExplosionRadius(), CustomExplosion.BlockBreakEffect.FIERY, Explosion.DestructionType.DESTROY);
     }
 }

--- a/src/main/java/ladysnake/blast/common/entity/NavalMineEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/NavalMineEntity.java
@@ -14,10 +14,12 @@ import net.minecraft.world.explosion.Explosion;
 public class NavalMineEntity extends BombEntity {
     public NavalMineEntity(EntityType<? extends BombEntity> entityType, World world) {
         super(entityType, world);
+        this.setExplosionRadius(4f);
     }
 
     public NavalMineEntity(EntityType<? extends BombEntity> entityType, World world, LivingEntity livingEntity) {
         super(entityType, world, livingEntity);
+        this.setExplosionRadius(4f);
     }
 
     @Override
@@ -27,7 +29,7 @@ public class NavalMineEntity extends BombEntity {
 
     @Override
     protected CustomExplosion getExplosion() {
-        return new CustomExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), 4f, CustomExplosion.BlockBreakEffect.AQUATIC, Explosion.DestructionType.BREAK);
+        return new CustomExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), this.getExplosionRadius(), CustomExplosion.BlockBreakEffect.AQUATIC, Explosion.DestructionType.BREAK);
 
     }
 

--- a/src/main/java/ladysnake/blast/common/entity/PearlBombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/PearlBombEntity.java
@@ -26,7 +26,7 @@ public class PearlBombEntity extends BombEntity {
 
     @Override
     protected CustomExplosion getExplosion() {
-        return new EnderExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), 3f, Explosion.DestructionType.BREAK);
+        return new EnderExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), this.getExplosionRadius(), Explosion.DestructionType.BREAK);
     }
 
     @Override

--- a/src/main/java/ladysnake/blast/common/entity/PearlTriggerBombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/PearlTriggerBombEntity.java
@@ -26,7 +26,7 @@ public class PearlTriggerBombEntity extends TriggerBombEntity {
 
     @Override
     protected CustomExplosion getExplosion() {
-        return new EnderExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), 3f, Explosion.DestructionType.BREAK);
+        return new EnderExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), this.getExplosionRadius(), Explosion.DestructionType.BREAK);
     }
 
     @Override

--- a/src/main/java/ladysnake/blast/common/entity/SlimeBombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/SlimeBombEntity.java
@@ -25,6 +25,6 @@ public class SlimeBombEntity extends BombEntity {
 
     @Override
     protected CustomExplosion getExplosion() {
-        return new KnockbackExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), 3f);
+        return new KnockbackExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), this.getExplosionRadius());
     }
 }

--- a/src/main/java/ladysnake/blast/common/entity/SlimeTriggerBombEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/SlimeTriggerBombEntity.java
@@ -25,7 +25,7 @@ public class SlimeTriggerBombEntity extends TriggerBombEntity {
 
     @Override
     protected CustomExplosion getExplosion() {
-        return new KnockbackExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), 3f);
+        return new KnockbackExplosion(this.world, this.getOwner(), this.getX(), this.getY(), this.getZ(), this.getExplosionRadius());
     }
 
 }

--- a/src/main/java/ladysnake/blast/common/entity/StripminerEntity.java
+++ b/src/main/java/ladysnake/blast/common/entity/StripminerEntity.java
@@ -30,6 +30,7 @@ public class StripminerEntity extends BombEntity {
     public StripminerEntity(EntityType<? extends BombEntity> entityType, World world) {
         super(entityType, world);
         this.setFuse(80);
+        this.setExplosionRadius(2.5f);
     }
 
     protected void initDataTracker() {
@@ -42,7 +43,7 @@ public class StripminerEntity extends BombEntity {
         for (int i = 0; i <= 24; i++) {
             BlockPos bp = this.getBlockPos().offset(this.getFacing(), i);
             if (world.getBlockState(bp).getBlock().getBlastResistance() < 1200) {
-                CustomExplosion explosion = new CustomExplosion(world, this, bp.getX() + 0.5, bp.getY() + 0.5, bp.getZ() + 0.5, 2.5f, null, Explosion.DestructionType.BREAK);
+                CustomExplosion explosion = new CustomExplosion(world, this, bp.getX() + 0.5, bp.getY() + 0.5, bp.getZ() + 0.5, this.getExplosionRadius(), null, Explosion.DestructionType.BREAK);
                 explosion.collectBlocksAndDamageEntities();
                 explosion.affectWorld(true);
             } else {


### PR DESCRIPTION
Makes it so that bombs will store their explosion radius as a variable.
Doesn't change the base mod but allows changing explosion radius with commands and allows other mods and datapacks to change the explosion size.
For example: `/summon blast:bomb ~ ~ ~ {Fuse:80,ExplosionRadius:40}` summon a bomb with a 4 second fuse and very large explosion radius.
This also supports the tag on items, such as `/give @s blast:bomb{ExplosionRadius:40}` allowing the same large explosion in the item form.