### PR TITLE
fix: never mark confetti particles as stopped, so they dont stick to ceilings or persist floating when the floor is removed

### DIFF
--- a/src/main/java/ladysnake/blast/client/particle/ConfettiParticle.java
+++ b/src/main/java/ladysnake/blast/client/particle/ConfettiParticle.java
@@ -6,17 +6,20 @@ import net.minecraft.client.particle.*;
 import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.world.ClientWorld;
+import net.minecraft.entity.Entity;
 import net.minecraft.particle.DefaultParticleType;
 import net.minecraft.registry.tag.FluidTags;
 import net.minecraft.util.math.*;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class ConfettiParticle extends SpriteBillboardParticle {
 
+    private static final double MAX_SQUARED_COLLISION_CHECK_DISTANCE = MathHelper.square(100.0);
     private static final Random RANDOM = new Random();
 
     private float slowing;
@@ -146,6 +149,32 @@ public class ConfettiParticle extends SpriteBillboardParticle {
             } else {
                 this.markDead();
             }
+        }
+    }
+
+    @Override
+    public void move(double dx, double dy, double dz) {
+        double d = dx;
+        double e = dy;
+        if (this.collidesWithWorld && (dx != 0.0 || dy != 0.0 || dz != 0.0) && dx * dx + dy * dy + dz * dz < MAX_SQUARED_COLLISION_CHECK_DISTANCE) {
+            Vec3d vec3d = Entity.adjustMovementForCollisions((Entity)null, new Vec3d(dx, dy, dz), this.getBoundingBox(), this.world, List.of());
+            dx = vec3d.x;
+            dy = vec3d.y;
+            dz = vec3d.z;
+        }
+
+        if (dx != 0.0 || dy != 0.0 || dz != 0.0) {
+            this.setBoundingBox(this.getBoundingBox().offset(dx, dy, dz));
+            this.repositionFromBoundingBox();
+        }
+
+        this.onGround = dy != dy && e < 0.0;
+        if (d != dx) {
+            this.velocityX = 0.0;
+        }
+
+        if (dz != dz) {
+            this.velocityZ = 0.0;
         }
     }
 

--- a/src/main/java/ladysnake/blast/client/particle/ConfettiParticle.java
+++ b/src/main/java/ladysnake/blast/client/particle/ConfettiParticle.java
@@ -7,20 +7,17 @@ import net.minecraft.client.particle.*;
 import net.minecraft.client.render.Camera;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.world.ClientWorld;
-import net.minecraft.entity.Entity;
 import net.minecraft.particle.DefaultParticleType;
 import net.minecraft.registry.tag.FluidTags;
 import net.minecraft.util.math.*;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 
-import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class ConfettiParticle extends SpriteBillboardParticle {
 
-    private static final double MAX_SQUARED_COLLISION_CHECK_DISTANCE = MathHelper.square(100.0);
     private static final Random RANDOM = new Random();
 
     private float slowing;

--- a/src/main/java/ladysnake/blast/client/particle/ConfettiParticle.java
+++ b/src/main/java/ladysnake/blast/client/particle/ConfettiParticle.java
@@ -1,5 +1,6 @@
 package ladysnake.blast.client.particle;
 
+import ladysnake.blast.mixin.client.ParticleAccessor;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.particle.*;
@@ -129,6 +130,7 @@ public class ConfettiParticle extends SpriteBillboardParticle {
                     this.velocityY = 0;
                 } else {
                     this.velocityY -= 0.04D * (double) this.gravityStrength;
+                    ((ParticleAccessor)this).setStopped(false);
                     this.move(this.velocityX, this.velocityY, this.velocityZ);
                     if (this.ascending && this.y == this.prevPosY) {
                         this.velocityX *= 1.1D;
@@ -149,32 +151,6 @@ public class ConfettiParticle extends SpriteBillboardParticle {
             } else {
                 this.markDead();
             }
-        }
-    }
-
-    @Override
-    public void move(double dx, double dy, double dz) {
-        double d = dx;
-        double e = dy;
-        if (this.collidesWithWorld && (dx != 0.0 || dy != 0.0 || dz != 0.0) && dx * dx + dy * dy + dz * dz < MAX_SQUARED_COLLISION_CHECK_DISTANCE) {
-            Vec3d vec3d = Entity.adjustMovementForCollisions((Entity)null, new Vec3d(dx, dy, dz), this.getBoundingBox(), this.world, List.of());
-            dx = vec3d.x;
-            dy = vec3d.y;
-            dz = vec3d.z;
-        }
-
-        if (dx != 0.0 || dy != 0.0 || dz != 0.0) {
-            this.setBoundingBox(this.getBoundingBox().offset(dx, dy, dz));
-            this.repositionFromBoundingBox();
-        }
-
-        this.onGround = dy != dy && e < 0.0;
-        if (d != dx) {
-            this.velocityX = 0.0;
-        }
-
-        if (dz != dz) {
-            this.velocityZ = 0.0;
         }
     }
 

--- a/src/main/java/ladysnake/blast/mixin/client/ParticleAccessor.java
+++ b/src/main/java/ladysnake/blast/mixin/client/ParticleAccessor.java
@@ -1,0 +1,11 @@
+package ladysnake.blast.mixin.client;
+
+import net.minecraft.client.particle.Particle;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Particle.class)
+public interface ParticleAccessor {
+    @Accessor
+    void setStopped(boolean value);
+}

--- a/src/main/resources/blast.mixins.json
+++ b/src/main/resources/blast.mixins.json
@@ -7,6 +7,9 @@
     "BundleItemMixin",
     "EnderEyeItemMixin"
   ],
+  "client": [
+    "client.ParticleAccessor"
+  ],
   "injectors": {
     "defaultRequire": 1
   }


### PR DESCRIPTION
closes #30
closes #31

Some code is copied from Particle.java. An alternative solution would involve an access widener or accessor mixin to access the `stopped` field from inside `ConfettiParticle#tick`. However, that felt like overkill when this solution was available without using any 'coremodding'. 